### PR TITLE
feat: add dependency checks and help target to Makefile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,21 @@
-.PHONY: start
+.PHONY: help check start
 
-start:
+help:
+	@echo "Usage:"
+	@echo "  make start   Start the application"
+	@echo "  make check   Verify required dependencies are installed"
+
+check:
+	@command -v flutter >/dev/null 2>&1 || { \
+		echo "Error: Flutter SDK is not installed." >&2; \
+		echo "" >&2; \
+		echo "  Install it from https://docs.flutter.dev/get-started/install or use your package manager:" >&2; \
+		echo "    brew install --cask flutter              # macOS" >&2; \
+		echo "    sudo snap install flutter --classic      # Ubuntu" >&2; \
+		exit 1; \
+	}
+
+start: check
 	test -f .env || cp .env.example .env
 	flutter pub get
 	flutter run -d chrome --web-port=$${PORT:-3000}


### PR DESCRIPTION
Add `check` target that validates Flutter SDK is installed before running, with install instructions for macOS and Linux. Running `make` now shows available targets.