### PR TITLE
fix: load .env in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: help check start
 
+ifneq (,$(wildcard .env))
+include .env
+endif
+
 help:
 	@echo "Usage:"
 	@echo "  make start   Start the application"


### PR DESCRIPTION
## Summary
- Add an `include .env` directive (guarded by `wildcard`) to the Makefile so values from the local `.env` file are available to Make recipes.

## Test plan
- [ ] `make help` still works without a `.env` file present
- [ ] With a `.env` file present, variables defined there are available in Make